### PR TITLE
Grouped context menu items into submenu

### DIFF
--- a/menus/tabs-to-spaces.cson
+++ b/menus/tabs-to-spaces.cson
@@ -1,8 +1,13 @@
 'context-menu':
   'atom-text-editor, .overlayer': [
-    { label: 'Tabify', command: 'tabs-to-spaces:tabify' }
-    { label: 'Untabify', command: 'tabs-to-spaces:untabify' }
-    { label: 'Untabify All', command: 'tabs-to-spaces:untabify-all' }
+    {
+      'label': 'Tabs to spaces'
+      'submenu': [
+        { label: 'Tabify', command: 'tabs-to-spaces:tabify' }
+        { label: 'Untabify', command: 'tabs-to-spaces:untabify' }
+        { label: 'Untabify All', command: 'tabs-to-spaces:untabify-all' }
+      ]
+    }
   ]
 
 'menu': [


### PR DESCRIPTION
Reason: prevents context menu pollution

![image](https://cloud.githubusercontent.com/assets/6587821/6886908/ddb323e0-d64e-11e4-944d-b75efcf50e15.png)
