### PR TITLE
Add configuration setting for number of spaces to convert to tab

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -9,7 +9,7 @@ module.exports =
       description: 'Setting this to anything other than `none` can **significantly** impact the time it takes to save large files.'
     tabLength:
       type: 'integer'
-      default: 2
+      default: atom.config.get('editor.tabLength') 
       description: 'Number of spaces to turn into a tab'
 
   # Public: Activates the package.

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -7,6 +7,10 @@ module.exports =
       default: 'none'
       enum: ['none', 'tabify', 'untabify']
       description: 'Setting this to anything other than `none` can **significantly** impact the time it takes to save large files.'
+    tabLength:
+      type: 'integer'
+      default: 2
+      description: 'Number of spaces to turn into a tab'
 
   # Public: Activates the package.
   activate: ->

--- a/lib/tabs-to-spaces.coffee
+++ b/lib/tabs-to-spaces.coffee
@@ -6,6 +6,9 @@ class TabsToSpaces
   # Private: Regular expression for matching leading whitespace on a line.
   leadingWhitespace: /^[ \t]+/g
 
+  # Private: Number of spaces to convert into a tab
+  tabLength: atom.config.get('tabs-to-spaces.tabLength')
+
   # Public: Converts all leading spaces to tabs in the current buffer.
   #
   # * `editor` (optional) {TextEditor} to tabify. Defaults to the active editor.
@@ -34,12 +37,11 @@ class TabsToSpaces
   # Returns the {Number} of spaces represented.
   countSpaces: (text) ->
     count = 0
-    tabLength = @editor.getTabLength()
 
     for ch in text
       switch ch
         when ' ' then count += 1
-        when '\t' then count += tabLength
+        when '\t' then count += @tabLength
 
     count
 
@@ -81,8 +83,8 @@ class TabsToSpaces
     editor.transact =>
       editor.scan @leadingWhitespace, ({match, replace}) =>
         count = @countSpaces(match[0])
-        tabs = count // @editor.getTabLength()
-        spaces = count %% @editor.getTabLength()
+        tabs = count // @tabLength
+        spaces = count %% @tabLength
         replace("#{@multiplyText('\t', tabs)}#{@multiplyText(' ', spaces)}")
 
 module.exports = new TabsToSpaces


### PR DESCRIPTION
Allow tabs-to-spaces number of spaces to convert to tabs to be different that the number of spaces that represent a tab.  Example: I use tabs that are 4 characters wide, but some of the code base uses 2 spaces.  I want to easily convert these without changing my display.