### PR TITLE
Reindents the file before applying conversion from spaces to tabs.

### DIFF
--- a/lib/tabs-to-spaces.js
+++ b/lib/tabs-to-spaces.js
@@ -116,6 +116,9 @@ class TabsToSpaces {
     const tabLength = editor.getTabLength()
     const buffer = editor.getBuffer()
 
+    // Ensure indentation of file matches user's preferences
+    editor.autoIndentBufferRows(0, editor.getLineCount() - 1)
+
     this.processBufferByLine(buffer, ({line, row}) => {
       const match = line.match(this.leadingWhitespace)
 


### PR DESCRIPTION
This fixes issue #51 too 

This fixes an issue where some of my PHP files with 4 space indentation were converting to 2 tabs for every 4 spaces. My editor uses 2 spaces to represent a tab, so it should really convert to 1 tab for every 4 spaces.

Work in progress...